### PR TITLE
Fix CEvent auto-reset behaviour in case of broadcast signal.

### DIFF
--- a/src/threads/mutex.h
+++ b/src/threads/mutex.h
@@ -351,7 +351,8 @@ namespace P8PLATFORM
     {
       CLockObject lock(m_mutex);
       bool bReturn(m_bSignaled);
-      if (bReturn && (--m_iWaitingThreads == 0 || !m_bBroadcast) && m_bAutoReset)
+      --m_iWaitingThreads;
+      if (bReturn && (m_iWaitingThreads == 0 || !m_bBroadcast) && m_bAutoReset)
         m_bSignaled = false;
       return bReturn;
     }


### PR DESCRIPTION
I probably found some minor issue with CEvent in auto-reset mode. When event becomes signalled by Broadcast() method, and some thread been waiting for event in a loop with timeout, the event remains signalled after successful checking of signal state. I.e. no automatic reset done. 

The issue was with a counter of waiting threads, that was not decremented, because of compiler optimisation of boolean expression. 

There is no issue when Signal() method is using.

Following is small test that fails before changes and succeeded after.

```
#include <iostream>
#include "threads/threads.h"

using namespace P8PLATFORM;

class bg_thread : public CThread
{
public:
    bg_thread(CEvent& e) : event(e)
    {}
    virtual void *Process(void)
    {
        bool isSignaled;
        do{
             isSignaled = event.Wait(1*1000);
            if(!isSignaled)
                std::cout << "Waited 1 sec. No signal\n";
            else
                std::cout << "Got signal!\n";
        }while(!isSignaled/* && !IsStopped()*/);
        std::cout << "Thread exit\n";

        return nullptr;
    }
private:
    CEvent& event;
};


int main(int argc, const char * argv[]) {
    // insert code here...
    CEvent event;
    bg_thread thread (event);
    thread.CreateThread();
    std::cout << "Will sleep 5 sec\n";
    CEvent::Sleep(5*1000);
    std::cout << "Signal event\n";
    //event.Signal();
    event.Broadcast();
    thread.StopThread();
    std::cout << "Thread stopped\n";
    if(event.Wait(100))
        std::cout << "Event is still in signal state!\n";
    else
        std::cout << "Timeout. OK, event is NOT signaled.\n";
    return 0;
}

```