### PR TITLE
Allow build with cmake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(p8-platform)
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.9...3.10)
 enable_language(CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake.

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html